### PR TITLE
docs: add qingming-z-image-turbo to Community Works

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Our core insight behind DMDR is that Reinforcement Learning (RL) and Distributio
 - [Candle](https://github.com/huggingface/candle) is a minimalist machine learning (ML) framework launched by Huggingface for Rust, which now [supports](https://github.com/huggingface/candle/pull/3261) Z-Image.
 - [MeanCache](https://github.com/UnicomAI/MeanCache), a training-free inference acceleration method for Flow Matching models by China Unicom Data Science and Artificial Intelligence Research Institute. Delivers up to **3.7x** speedup for **Z-Image** generation with plug-and-play integration while preserving output quality.
 
+- [qingming-z-image-turbo](https://github.com/uulong950/qingming-z-image-turbo) is a native HIP/C++ inference implementation of Z-Image-Turbo for AMD ROCm, specifically optimized and validated for AMD Radeon RX 7900 XTX 24GB / gfx1100. It supports BF16, Q8_0, Q6_K, and Q5_K_M execution paths without requiring PyTorch, Diffusers, ComfyUI, or a Python runtime.
+
 ## 🚀 Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Tongyi-MAI/Z-Image&type=date&legend=top-left)](https://www.star-history.com/#Tongyi-MAI/Z-Image&type=date&legend=top-left)


### PR DESCRIPTION
## Summary

This PR adds `qingming-z-image-turbo` to the **Community Works** section.

Project:

https://github.com/uulong950/qingming-z-image-turbo

`qingming-z-image-turbo` is an unofficial native HIP/C++ inference implementation of Z-Image-Turbo for AMD ROCm, specifically optimized and validated for AMD Radeon RX 7900 XTX 24GB / gfx1100.

It provides:

* Native C++/HIP/ROCm inference
* Custom gfx1100 BF16 WMMA kernels
* BF16, Q8_0, Q6_K, and Q5_K_M execution paths
* Fully GPU-resident inference
* Support for 512×512, 576×1024, and 1024×1024
* No PyTorch, Diffusers, ComfyUI, or Python runtime dependency

This project adds an AMD ROCm / gfx1100-native inference option to the Z-Image community ecosystem.

The repository includes source code, model download scripts, build instructions, benchmark results, and generated output comparisons.

Thank you to the Z-Image team for releasing the official model and implementation.
